### PR TITLE
return values based no mode

### DIFF
--- a/src/Drivers/Database.php
+++ b/src/Drivers/Database.php
@@ -173,6 +173,18 @@ class Database extends Translation implements DriverInterface
             return $this->getSingleTranslationsFor($language);
         }
 
+
+        if(session()->has('translation_enabled')){
+            if(session()->get('translation_enabled') === false){
+                return $translations->map(function ($translations, $group) {
+                    return $translations->mapWithKeys(function ($translation) {
+                        return [$translation->key => $translation->group.'.'.$translation->key];
+                    });
+                });
+            }
+        }
+        
+
         return $translations->map(function ($translations, $group) {
             return $translations->mapWithKeys(function ($translation) {
                 return [$translation->key => $translation->value];
@@ -194,6 +206,16 @@ class Database extends Translation implements DriverInterface
             ->where('group', 'not like', '%single')
             ->get()
             ->groupBy('group');
+
+        if(session()->has('translation_enabled')){
+            if(session()->get('translation_enabled') === false){
+                return $translations->map(function ($translations, $group) {
+                    return $translations->mapWithKeys(function ($translation) {
+                        return [$translation->key => $translation->group.'.'.$translation->key];
+                    });
+                });
+            }
+        }
 
         return $translations->map(function ($translations) {
             return $translations->mapWithKeys(function ($translation) {


### PR DESCRIPTION
https://evulpo-company.monday.com/boards/3750437337/views/84953271/pulses/3763686137

@ledanni this is our fork of the TMS-package that we use for evulpo as a vendor. By modifying the return values of the translations depending on a session-variable, we can switch between "normal-mode" and "key-highlighting"