### PR TITLE
Routing and controller for bulk edit support

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -19,8 +19,8 @@ Route::group(config('translation.route_group_config') + ['namespace' => 'JoeDixo
     $router->get(config('translation.ui_url').'/{language}/translations/create', 'LanguageTranslationController@create')
         ->name('languages.translations.create');
 
-    $router->post(config('translation.ui_url').'/{language}/translations', 'LanguageTranslationController@store')
-        ->name('languages.translations.store');
+    $router->get(config('translation.ui_url').'/{language}/translations/{group}/{key}/update', 'LanguageTranslationController@updateTranslation')
+        ->name('languages.translations.updateTranslation');
 
     $router->post(config('translation.ui_url').'/{language}/translations', 'LanguageTranslationController@storeAll')
         ->name('languages.translations.storeAll');


### PR DESCRIPTION
1. Created routing and controller for bulk edit support.
2. Removed redundant routing for `/{language}/translations`.
3. Removed unnecessary controller method `store`.