### PR TITLE
Fix the TMS which always ADD key and group in lowercase characters.

### DIFF
--- a/src/Http/Controllers/LanguageTranslationController.php
+++ b/src/Http/Controllers/LanguageTranslationController.php
@@ -95,7 +95,7 @@ class LanguageTranslationController extends Controller
         if ($request->filled('group')) {	
             $namespace = $request->has('namespace') && $request->get('namespace') ? "{$request->get('namespace')}::" : '';	
             foreach($languages as $i => $lang){	
-                $this->translation->addGroupTranslation($lang->name,"{$namespace}{$request->get('group')}",$request->get('key'), $request['value'.$i]);	
+                $this->translation->addGroupTranslation($lang->name,"{$namespace}{$request->get('group')}", $request->get('key'), $request['value'.$i]);	
             }
         } else {	
             foreach($languages as $i => $lang){	

--- a/src/Http/Controllers/LanguageTranslationController.php
+++ b/src/Http/Controllers/LanguageTranslationController.php
@@ -95,11 +95,11 @@ class LanguageTranslationController extends Controller
         if ($request->filled('group')) {	
             $namespace = $request->has('namespace') && $request->get('namespace') ? "{$request->get('namespace')}::" : '';	
             foreach($languages as $i => $lang){	
-                $this->translation->addGroupTranslation($lang->name,("{$namespace}{$request->get('group')}"),($request->get('key')), $request['value'.$i]);	
+                $this->translation->addGroupTranslation($lang->name,"{$namespace}{$request->get('group')}",$request->get('key'), $request['value'.$i]);	
             }
         } else {	
             foreach($languages as $i => $lang){	
-                $this->translation->addSingleTranslation($lang->name, 'single',($request->get('key')), $request['value'.$i]);	
+                $this->translation->addSingleTranslation($lang->name, 'single',$request->get('key'), $request['value'.$i]);	
             }	
         }	
         return redirect()	

--- a/src/Http/Controllers/LanguageTranslationController.php
+++ b/src/Http/Controllers/LanguageTranslationController.php
@@ -95,11 +95,11 @@ class LanguageTranslationController extends Controller
         if ($request->filled('group')) {	
             $namespace = $request->has('namespace') && $request->get('namespace') ? "{$request->get('namespace')}::" : '';	
             foreach($languages as $i => $lang){	
-                $this->translation->addGroupTranslation($lang->name, strtolower("{$namespace}{$request->get('group')}"), strtolower($request->get('key')), $request['value'.$i]);	
+                $this->translation->addGroupTranslation($lang->name,("{$namespace}{$request->get('group')}"),($request->get('key')), $request['value'.$i]);	
             }
         } else {	
             foreach($languages as $i => $lang){	
-                $this->translation->addSingleTranslation($lang->name, 'single', strtolower($request->get('key')), $request['value'.$i]);	
+                $this->translation->addSingleTranslation($lang->name, 'single',($request->get('key')), $request['value'.$i]);	
             }	
         }	
         return redirect()	

--- a/src/Http/Controllers/LanguageTranslationController.php
+++ b/src/Http/Controllers/LanguageTranslationController.php
@@ -99,7 +99,7 @@ class LanguageTranslationController extends Controller
             }
         } else {	
             foreach($languages as $i => $lang){	
-                $this->translation->addSingleTranslation($lang->name, 'single',$request->get('key'), $request['value'.$i]);	
+                $this->translation->addSingleTranslation($lang->name, 'single', $request->get('key'), $request['value'.$i]);	
             }	
         }	
         return redirect()	


### PR DESCRIPTION
Item ID: 6062630328
1. Currently whenever the admin tries to ADD translations, it adds key and group in lowercase and thus not respect the given casing. 
2. With the fix, we will store key and group according to their given casing.